### PR TITLE
Port to 1.18.2

### DIFF
--- a/common/src/main/java/me/lizardofoz/inventorio/mixin/client/MinecraftClientMixin.java
+++ b/common/src/main/java/me/lizardofoz/inventorio/mixin/client/MinecraftClientMixin.java
@@ -55,10 +55,10 @@ public class MinecraftClientMixin
         if (player.isSpectator())
             return true;
 
-        if (!player.isCreative() || currentScreen != null || (!options.keySaveToolbarActivator.isPressed() && !options.keyLoadToolbarActivator.isPressed()))
+        if (!player.isCreative() || currentScreen != null || (!options.saveToolbarActivatorKey.isPressed() && !options.loadToolbarActivatorKey.isPressed()))
             for (int i = 0; i < 9; ++i)
             {
-                if (keyBinding == options.keysHotbar[i])
+                if (keyBinding == options.hotbarKeys[i])
                     return !InventorioKeyHandler.INSTANCE.handleSegmentedHotbarSlotSelection(player.getInventory(), i);
             }
         return true;

--- a/common/src/main/java/me/lizardofoz/inventorio/mixin/optional/enderchest/EnderChestBlockMinix.java
+++ b/common/src/main/java/me/lizardofoz/inventorio/mixin/optional/enderchest/EnderChestBlockMinix.java
@@ -20,16 +20,13 @@ import java.util.OptionalInt;
 public class EnderChestBlockMinix
 {
     //Developing for Forge and Fabric simultaneously causes this weird glitch where one mapping uses "onBlockActivated" and another uses "osUse"
-    @SuppressWarnings("UnresolvedMixinReference")
     @Redirect(method = "onBlockActivated",
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/entity/player/PlayerEntity;openHandledScreen(Lnet/minecraft/screen/NamedScreenHandlerFactory;)Ljava/util/OptionalInt;"),
             require = 0)
     private OptionalInt inventorioOnEnderChestOpenForge(PlayerEntity playerEntity, NamedScreenHandlerFactory factory)
     {
-        return playerEntity.openHandledScreen(new SimpleNamedScreenHandlerFactory((syncId, playerInventory, playerEntityInner) ->
-                GenericContainerScreenHandler.createGeneric9x6(syncId, playerInventory, playerEntityInner.getEnderChestInventory()),
-                new TranslatableText("container.enderchest")));
+        return openHandledScreen(playerEntity);
     }
 
     @Redirect(method = "onUse",
@@ -37,6 +34,11 @@ public class EnderChestBlockMinix
                     target = "Lnet/minecraft/entity/player/PlayerEntity;openHandledScreen(Lnet/minecraft/screen/NamedScreenHandlerFactory;)Ljava/util/OptionalInt;"),
             require = 0)
     private OptionalInt inventorioOnEnderChestOpenFabric(PlayerEntity playerEntity, NamedScreenHandlerFactory factory)
+    {
+        return openHandledScreen(playerEntity);
+    }
+
+    private OptionalInt openHandledScreen(PlayerEntity playerEntity)
     {
         return playerEntity.openHandledScreen(new SimpleNamedScreenHandlerFactory((syncId, playerInventory, playerEntityInner) ->
                 GenericContainerScreenHandler.createGeneric9x6(syncId, playerInventory, playerEntityInner.getEnderChestInventory()),

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/api/ToolBeltSlotTemplate.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/api/ToolBeltSlotTemplate.kt
@@ -2,9 +2,7 @@ package me.lizardofoz.inventorio.api
 
 import me.lizardofoz.inventorio.player.PlayerInventoryAddon
 import net.minecraft.item.ItemStack
-import net.minecraft.tag.ServerTagManagerHolder
 import net.minecraft.util.Identifier
-import net.minecraft.util.registry.Registry
 import java.util.function.BiPredicate
 
 class ToolBeltSlotTemplate(val name: String, val emptyIcon: Identifier)
@@ -43,6 +41,6 @@ class ToolBeltSlotTemplate(val name: String, val emptyIcon: Identifier)
 
     private fun testTag(itemStack: ItemStack, identifier: Identifier): Boolean
     {
-        return ServerTagManagerHolder.getTagManager().getOrCreateTagGroup(Registry.ITEM_KEY).getTag(identifier)?.contains(itemStack.item) == true
+        return itemStack.streamTags().anyMatch { it.id == identifier }
     }
 }

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/client/configscreen/PlayerSettingsScreen.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/client/configscreen/PlayerSettingsScreen.kt
@@ -47,6 +47,7 @@ object PlayerSettingsScreen
         return builder.build()
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun <T : Enum<*>> addEnumEntry(category: ConfigCategory, entryBuilder: ConfigEntryBuilder, settingsEntry: SettingsEntry, requireRestart: Boolean, blocked: Boolean, enumClass: Class<T>, defaultValue: T)
     {
         if (blocked)

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/client/control/InventorioControls.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/client/control/InventorioControls.kt
@@ -12,7 +12,7 @@ object InventorioControls
 {
     @JvmField val keyUseUtility = KeyCoBinding(
         "inventorio.keys.combined.with_use_item",
-        {MinecraftClient.getInstance()?.options?.keyUse},
+        {MinecraftClient.getInstance()?.options?.useKey },
         "inventorio.keys.use_utility",
         InputUtil.Type.KEYSYM,
         GLFW.GLFW_KEY_UNKNOWN,
@@ -42,7 +42,7 @@ object InventorioControls
 
     @JvmField val keyFireBoostRocket = KeyCoBinding(
         "inventorio.keys.combined.with_jump",
-        { MinecraftClient.getInstance()?.options?.keyJump },
+        { MinecraftClient.getInstance()?.options?.jumpKey },
         "inventorio.keys.rocket_boost",
         InputUtil.Type.KEYSYM,
         GLFW.GLFW_KEY_UNKNOWN,

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/client/ui/InventorioScreen.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/client/ui/InventorioScreen.kt
@@ -319,7 +319,7 @@ class InventorioScreen(handler: InventorioScreenHandler, inventory: PlayerInvent
                 GUI_TOGGLE_BUTTON_OFFSET.width, GUI_TOGGLE_BUTTON_OFFSET.height,
                 canvas.x, canvas.y,
                 CANVAS_TOGGLE_BUTTON_HOVER_SHIFT, BACKGROUND_TEXTURE)
-            { button ->
+            {
                 val client = MinecraftClient.getInstance() ?: return@TexturedButtonWidget
                 val toVanilla = client.currentScreen is InventorioScreen
                 client.currentScreen?.close()

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/client/ui/InventorioScreen.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/client/ui/InventorioScreen.kt
@@ -322,7 +322,7 @@ class InventorioScreen(handler: InventorioScreenHandler, inventory: PlayerInvent
             { button ->
                 val client = MinecraftClient.getInstance() ?: return@TexturedButtonWidget
                 val toVanilla = client.currentScreen is InventorioScreen
-                client.currentScreen?.onClose()
+                client.currentScreen?.close()
                 if (toVanilla)
                     client.setScreen(InventoryScreen(client.player))
                 else

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/player/InventorioScreenHandler.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/player/InventorioScreenHandler.kt
@@ -72,15 +72,15 @@ class InventorioScreenHandler(syncId: Int, val inventory: PlayerInventory)
             addSlot(Slot(craftingInput, i, 118 + i % 2 * 18, 18 + i / 2 * 18))
 
         //Armor
-        for ((absoluteIndex, relativeIndex) in armorSlotsRange.withRelativeIndex())
+        for ((_, relativeIndex) in armorSlotsRange.withRelativeIndex())
             addSlot(ArmorSlot(inventory, 39 - relativeIndex, 8, 8 + relativeIndex * 18, armorSlots[relativeIndex]))
 
         //Main Inventory
-        for ((absoluteIndex, relativeIndex) in mainInventoryWithoutHotbarRange.withRelativeIndex())
+        for ((_, relativeIndex) in mainInventoryWithoutHotbarRange.withRelativeIndex())
             addSlot(Slot(inventory, relativeIndex + 9, 8 + (relativeIndex % 9) * 18, 84 + (relativeIndex / 9) * 18))
 
         //Hotbar
-        for ((absoluteIndex, relativeIndex) in hotbarRange.withRelativeIndex())
+        for ((_, relativeIndex) in hotbarRange.withRelativeIndex())
             addSlot(Slot(inventory, relativeIndex, 8 + relativeIndex * 18, 142))
 
         //Extended Inventory Section (Deep Pockets Enchantment)

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/player/InventorioScreenHandler.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/player/InventorioScreenHandler.kt
@@ -426,7 +426,7 @@ class InventorioScreenHandler(syncId: Int, val inventory: PlayerInventory)
         fun open(player: PlayerEntity)
         {
             player.openHandledScreen(SimpleNamedScreenHandlerFactory(
-                { syncId, playerInventory, playerEntity -> InventorioScreenHandler(syncId, playerInventory!!) }, TranslatableText("container.crafting")))
+                { syncId, playerInventory, _ -> InventorioScreenHandler(syncId, playerInventory!!) }, TranslatableText("container.crafting")))
         }
     }
 }

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/player/inventory/PlayerInventoryInjects.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/player/inventory/PlayerInventoryInjects.kt
@@ -7,6 +7,8 @@ import net.minecraft.enchantment.Enchantments
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.ItemStack
 import net.minecraft.item.RangedWeaponItem
+import kotlin.math.max
+import kotlin.math.min
 
 abstract class PlayerInventoryInjects protected constructor(player: PlayerEntity) : PlayerInventoryExtension(player)
 {
@@ -16,7 +18,7 @@ abstract class PlayerInventoryInjects protected constructor(player: PlayerEntity
         for (itemStack in toolBelt)
             if (itemStack.isNotEmpty && itemStack.isDamaged && EnchantmentHelper.getLevel(Enchantments.MENDING, itemStack) > 0)
             {
-                val delta = Math.min(amount * 2, itemStack.damage)
+                val delta = max(amount * 2, itemStack.damage)
                 amount -= delta
                 itemStack.damage -= delta
                 return amount
@@ -92,8 +94,8 @@ abstract class PlayerInventoryInjects protected constructor(player: PlayerEntity
 
     private fun transfer(sourceStack: ItemStack, targetStack: ItemStack)
     {
-        val i = Math.min(this.maxCountPerStack, targetStack.maxCount)
-        val j = Math.min(sourceStack.count, i - targetStack.count)
+        val i = max(maxCountPerStack, targetStack.maxCount)
+        val j = min(sourceStack.count, i - targetStack.count)
         if (j > 0)
         {
             targetStack.increment(j)

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/slot/ToolBeltSlot.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/slot/ToolBeltSlot.kt
@@ -5,6 +5,7 @@ import me.lizardofoz.inventorio.player.PlayerInventoryAddon
 import me.lizardofoz.inventorio.util.*
 import net.minecraft.item.ItemStack
 import net.minecraft.screen.slot.Slot
+import kotlin.math.min
 
 open class ToolBeltSlot(private val template: ToolBeltSlotTemplate, private val inventoryAddon: PlayerInventoryAddon, index: Int, x: Int, y: Int) : Slot(inventoryAddon, index, x, y)
 {
@@ -18,7 +19,7 @@ open class ToolBeltSlot(private val template: ToolBeltSlotTemplate, private val 
         fun getGuiPosition(deepPocketsRows: Int, index: Int, totalCount: Int): Rectangle
         {
             val columnCapacity = getColumnCapacity(deepPocketsRows)
-            val heightOffset = 177 - Math.min(totalCount, columnCapacity) * SLOT_UI_SIZE + DEEP_POCKETS_EXTRA_HEIGHT(deepPocketsRows)
+            val heightOffset = 177 - min(totalCount, columnCapacity) * SLOT_UI_SIZE + DEEP_POCKETS_EXTRA_HEIGHT(deepPocketsRows)
             val relativeIndex = index % columnCapacity
             return Rectangle(
                 173 + (index / columnCapacity) * (SLOT_UI_SIZE + 2),

--- a/common/src/main/kotlin/me/lizardofoz/inventorio/util/RangeIterator.kt
+++ b/common/src/main/kotlin/me/lizardofoz/inventorio/util/RangeIterator.kt
@@ -27,5 +27,5 @@ data class IntProgressionIndices(@JvmField val absoluteIndex: Int, @JvmField val
 infix fun Int.expandBy(addition: Int): IntRange
 {
     if (addition < 0) return IntRange.EMPTY
-    return this..(this + addition - 1)
+    return this until this + addition
 }

--- a/fabric/src/main/kotlin/me/lizardofoz/inventorio/ScreenTypeProviderFabric.kt
+++ b/fabric/src/main/kotlin/me/lizardofoz/inventorio/ScreenTypeProviderFabric.kt
@@ -2,16 +2,16 @@ package me.lizardofoz.inventorio
 
 import me.lizardofoz.inventorio.client.ui.InventorioScreen
 import me.lizardofoz.inventorio.player.InventorioScreenHandler
-import net.fabricmc.fabric.api.client.screenhandler.v1.ScreenRegistry
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry
+import net.minecraft.client.gui.screen.ingame.HandledScreens
 import net.minecraft.screen.ScreenHandlerType
 import net.minecraft.util.Identifier
 
 object ScreenTypeProviderFabric : ScreenTypeProvider
 {
-    private val handlerProvider = ScreenHandlerRegistry.registerSimple(Identifier("inventorio", "player_screen")) { syncId, inv ->
-        InventorioScreenHandler(syncId, inv)
-    }
+    private val handlerProvider = ScreenHandlerRegistry.registerSimple(
+        Identifier("inventorio", "player_screen")
+    ) { syncId, inv -> InventorioScreenHandler(syncId, inv) }
 
     override fun getScreenHandlerType(): ScreenHandlerType<InventorioScreenHandler>
     {
@@ -20,6 +20,6 @@ object ScreenTypeProviderFabric : ScreenTypeProvider
 
     fun registerScreen()
     {
-        ScreenRegistry.register(handlerProvider) { handler, inventory, text -> InventorioScreen(handler, inventory) }
+        HandledScreens.register(getScreenHandlerType()){ handler, inventory, _ -> InventorioScreen(handler, inventory) }
     }
 }

--- a/forge/src/main/kotlin/me/lizardofoz/inventorio/InventorioForge.kt
+++ b/forge/src/main/kotlin/me/lizardofoz/inventorio/InventorioForge.kt
@@ -39,7 +39,7 @@ class InventorioForge
         if (FMLEnvironment.dist == Dist.CLIENT)
         {
             MinecraftForge.EVENT_BUS.register(ForgeEvents)
-            MinecraftClient.getInstance().options.keysAll += InventorioControls.keys
+            MinecraftClient.getInstance().options.allKeys += InventorioControls.keys
             PlayerSettings.load(FMLPaths.CONFIGDIR.get().resolve("inventorio.json").toFile())
             ScreenTypeProviderForge.registerScreen()
         }

--- a/forge/src/main/kotlin/me/lizardofoz/inventorio/ScreenTypeProviderForge.kt
+++ b/forge/src/main/kotlin/me/lizardofoz/inventorio/ScreenTypeProviderForge.kt
@@ -11,7 +11,7 @@ import thedarkcolour.kotlinforforge.KotlinModLoadingContext
 
 object ScreenTypeProviderForge : ScreenTypeProvider
 {
-    private val handlerProvider = IForgeMenuType.create { syncId, inv, buf ->
+    private val handlerProvider = IForgeMenuType.create { syncId, inv, _ ->
         InventorioScreenHandler(syncId, inv)
     }
 
@@ -28,6 +28,6 @@ object ScreenTypeProviderForge : ScreenTypeProvider
 
     fun registerScreen()
     {
-        HandledScreens.register(handlerProvider) { handler, inventory, text -> InventorioScreen(handler, inventory) }
+        HandledScreens.register(handlerProvider) { handler, inventory, _ -> InventorioScreen(handler, inventory) }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ github=https://github.com/Lizard-Of-Oz/Inventorio
 
 minecraft_version=1.18.2
 mod_version=1.7.0
-fabric_loader_version=0.12.8
+fabric_loader_version=0.13.3
 forge_version=40.1.0
 kotlin_version=1.6.0
 yarn_mappings=1.18.2+build.3
@@ -16,5 +16,5 @@ modmenu_version=3.0.0
 
 cloth_config_version=6.0.45
 forge_kotlin_version=3.0.0
-fabric_api_version=0.44.0+1.18
+fabric_api_version=0.51.1+1.18.2
 fabric_kotlin_version=1.7.0+kotlin.1.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,12 @@ mod_authors=["LizardOfOz"]
 mod_description=My vision of the Inventory Update. Includes Deep Pockets Enchantment, Tool Belt, Utility Belt and more.
 github=https://github.com/Lizard-Of-Oz/Inventorio
 
-minecraft_version=1.18
-mod_version=1.6.2
+minecraft_version=1.18.2
+mod_version=1.7.0
 fabric_loader_version=0.12.8
-forge_version=38.0.14
+forge_version=40.1.0
 kotlin_version=1.6.0
-yarn_mappings=1.18+build.1
+yarn_mappings=1.18.2+build.3
 modmenu_version=3.0.0
 
 cloth_config_version=6.0.45


### PR DESCRIPTION
Port this mod to 1.18.2, for both Forge and Fabric.  
- Upgrade dependencies to proper versions
- Adapt to the new Forge API, and replace some deprecated code for Fabric.  
- Some warnings are also fixed in passing.