### PR TITLE
Set the right Java Version for the right Minecraft Version and added the minVersion tag

### DIFF
--- a/common/src/main/resources/inventorio.mixins.json
+++ b/common/src/main/resources/inventorio.mixins.json
@@ -1,7 +1,8 @@
 {
   "required": true,
   "package": "me.lizardofoz.inventorio.mixin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_16",
+  "minVersion": "0.8",
   "plugin": "me.lizardofoz.inventorio.InventorioMixinPlugin",
   "mixins": [
     "ExperienceOrbEntityMixin",


### PR DESCRIPTION
To fix this Error:
```
[main/DEBUG] [mixin/]: Compatibility level JAVA_8 specified by inventorio.mixins.json is lower than the default level supported by the current mixin service (JAVA_16).
[main/ERROR] [mixin/]: Mixin config inventorio.mixins.json does not specify "minVersion" property
```