### PR TITLE
fix: NeoForge fixes

### DIFF
--- a/neoforge/src/main/kotlin/me/lizardofoz/inventorio/InventorioNeoForge.kt
+++ b/neoforge/src/main/kotlin/me/lizardofoz/inventorio/InventorioNeoForge.kt
@@ -43,7 +43,9 @@ class InventorioNeoForge
 
         val recipeRegistry = DeferredRegister.create(Registries.RECIPE_SERIALIZER, "inventorio")
         recipeRegistry.register(KotlinModLoadingContext.get().getKEventBus())
-        recipeRegistry.register("deep_pockets_book") { -> SpecialRecipeSerializer { category -> DeepPocketsBookRecipe(category) } }
+        val serializer = SpecialRecipeSerializer { category -> DeepPocketsBookRecipe(category) }
+        DeepPocketsBookRecipe.SERIALIZER = serializer
+        recipeRegistry.register("deep_pockets_book") { -> serializer }
 
         initToolBelt()
         KotlinModLoadingContext.get().getKEventBus().register(InventorioNetworkingNeoForge)

--- a/neoforge/src/main/kotlin/me/lizardofoz/inventorio/packet/InventorioNetworkingNeoForge.kt
+++ b/neoforge/src/main/kotlin/me/lizardofoz/inventorio/packet/InventorioNetworkingNeoForge.kt
@@ -64,7 +64,7 @@ object InventorioNetworkingNeoForge : InventorioNetworking
     override fun c2sSetSwappedHandsMode(swappedHands: Boolean)
     {
         if (MinecraftClient.getInstance().networkHandler != null)
-            PacketDistributor.SERVER.noArg().send()
+            PacketDistributor.SERVER.noArg().send(SwappedHandsModeC2SPacket(swappedHands))
     }
 
     @OnlyIn(Dist.CLIENT)


### PR DESCRIPTION
This PR fixes two small oversights in my previous PR (#309).

- lateinit `DeepPocketsBookRecipe.SERIALIZER` never got initialized
  - while updating the registration code for NeoForge I seem to accidentally have removed the assignment to `DeepPocketsBookRecipe.SERIALIZER` causing an error when trying to connect to a server
- `SwappedHandsModeC2SPacket` never got send
  - the `send` call for sending the `SwappedHandsModeC2SPacket` didn't actually send anything, which caused the desync you mentioned

---

Also somewhat unrelated, you said you were unable to setup a NeoForge server. That is probably because of https://github.com/neoforged/NeoForge/issues/651